### PR TITLE
Add SERVER_TAG feature

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -98,4 +98,4 @@ Configurations can use the CLI flags or environment variables. The table below o
 | `--mailhost`          | `MAIL_HOST`             | `""`    | `smtp@provider.com` |
 | `--filter`            | `FILTER`                | `""`    | Filter events. Uses the same filters as `docker events` (see [here](https://docs.docker.com/engine/reference/commandline/events/#filter))    |
 | `--loglevel`          | `LOG_LEVEL`             | `"info"`| Use `debug` for more verbose logging |
-| `--servertag`         | `SERVER_TAG`            | `""`    | Useful when running docker-event-monitors on multiple machines |
+| `--servertag`         | `SERVER_TAG`            | `""`    | Prefix to include in the title of notifications. Useful when running docker-event-monitors on multiple machines |

--- a/Readme.md
+++ b/Readme.md
@@ -97,4 +97,5 @@ Configurations can use the CLI flags or environment variables. The table below o
 | `--mailport`          | `MAIL_PORT`             | `587`   | |
 | `--mailhost`          | `MAIL_HOST`             | `""`    | `smtp@provider.com` |
 | `--filter`            | `FILTER`                | `""`    | Filter events. Uses the same filters as `docker events` (see [here](https://docs.docker.com/engine/reference/commandline/events/#filter))    |
-| `--loglevel`          | `LOG_LEVEL`             | `"info"`| Use `debug` for more verbose logging` |
+| `--loglevel`          | `LOG_LEVEL`             | `"info"`| Use `debug` for more verbose logging |
+| `--servertag`         | `SERVER_TAG`            | `""`    | Useful when running docker-event-monitors on multiple machines |

--- a/src/docker-event-monitor.go
+++ b/src/docker-event-monitor.go
@@ -42,6 +42,7 @@ type args struct {
 	FilterStrings    []string            `arg:"env:FILTER,--filter,separate" help:"Filter docker events using Docker syntax."`
 	Filter           map[string][]string `arg:"-"`
 	LogLevel         string              `arg:"env:LOG_LEVEL" default:"info" help:"Set log level. Use debug for more logging."`
+	ServerTag        string              `arg:"env:SERVER_TAG" help:"Prefix to include in the title of notifications. Useful when running docker-event-monitors on multiple machines."`
 }
 
 // hold the supplied run-time arguments globally
@@ -145,6 +146,11 @@ func sendNotifications(message, title string) {
 	// otherwise delaying in processEvent() would not make any sense
 
 	var wg sync.WaitGroup
+
+	// If there is a server tag, add it to the title
+	if len(glb_arguments.ServerTag) > 0 {
+		title = "[" + glb_arguments.ServerTag + "] " + title
+	}
 
 	if glb_arguments.Pushover {
 		wg.Add(1)


### PR DESCRIPTION
Fixes https://github.com/yubiuser/docker-event-monitor/issues/35

``` yml
  environment:
    SERVER_TAG: 'ryzen'
```

![Screenshot from 2023-09-23 14-23-22](https://github.com/yubiuser/docker-event-monitor/assets/16748619/d7001ce6-d081-48bc-86a1-dfdafe8ae5d3)
