### PR TITLE
Restructure title/message and add docker compose context and service names (if available)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -14,7 +14,7 @@ Monitor Docker events and send push notifications for each event.
 
 ## Background
 
-I've been using [Monocker](https://github.com/petersem/monocker) to monitor my Docker containers and get push notifications on status changes. However, it's using polling (with hard lower limit of 10 sec) to poll for status changes. This is too long to catch all status changes (e.g. watchtower updating an container). While I did remove the limit in my own Monocker fork, I noticed that the CPU usage goes up quite a bit for polling times < 1sec.
+I've been using [Monocker](https://github.com/petersem/monocker) to monitor my Docker containers and get push notifications on status changes. However, it's using polling (with hard lower limit of 10 sec) to poll for status changes. This is too long to catch all status changes (e.g. watchtower updating a container). While I did remove the limit in my own Monocker fork, I noticed that the CPU usage goes up quite a bit for polling times < 1sec.
 I needed another soultion, and found [docker-events-notifier](https://github.com/hasnat/docker-events-notifier), but Pushover integration was missing.
 
 So I started to develop my own solution which ended up being a `bash` script doing exactly what I wanted it to do (you can still find it in `/legacy/`). However, the used `jq` caused CPU spikes for each processed event. As I could not find a good solution, I decied to write my own application and to learn something new - [Go](https://go.dev/).

--- a/src/docker-event-monitor.go
+++ b/src/docker-event-monitor.go
@@ -91,30 +91,34 @@ func init() {
 
 func main() {
 
-	log.Infof("Starting docker event monitor")
+	log.Info("Starting docker event monitor")
+
+	var info string
 
 	if glb_arguments.Pushover {
-		log.Infof("Notify via Pushover, using API Token %s and user key %s", glb_arguments.PushoverAPIToken, glb_arguments.PushoverUserKey)
+		info = fmt.Sprintf("Notify via Pushover, using API Token %s and user key %s", glb_arguments.PushoverAPIToken, glb_arguments.PushoverUserKey)
 	} else {
-		log.Info("Pushover notification disabled")
+		info = "Pushover notification disabled"
 	}
 
 	if glb_arguments.Gotify {
-		log.Infof("Notify via Gotify, using URL %s and APP Token %s", glb_arguments.GotifyURL, glb_arguments.GotifyToken)
+		info += fmt.Sprintf("\nNotify via Gotify, using URL %s and APP Token %s", glb_arguments.GotifyURL, glb_arguments.GotifyToken)
 	} else {
-		log.Info("Gotify notification disabled")
+		info += "\nGotify notification disabled"
 	}
 	if glb_arguments.Mail {
-		log.Infof("Notify via E-Mail from %s to %s using host %s and port %d", glb_arguments.MailFrom, glb_arguments.MailTo, glb_arguments.MailHost, glb_arguments.MailPort)
+		info += fmt.Sprintf("\nNotify via E-Mail from %s to %s using host %s and port %d", glb_arguments.MailFrom, glb_arguments.MailTo, glb_arguments.MailHost, glb_arguments.MailPort)
 	} else {
-		log.Info("E-Mail notification disabled")
+		info += "\nE-Mail notification disabled"
 	}
 
 	if glb_arguments.Delay > 0 {
-		log.Infof("Using delay of %v", glb_arguments.Delay)
+		info += fmt.Sprintf("\nUsing delay of %v", glb_arguments.Delay)
 	} else {
-		log.Info("Delay disabled")
+		info += "\nDelay disabled"
 	}
+
+	log.Info(info)
 
 	filterArgs := filters.NewArgs()
 	for key, values := range glb_arguments.Filter {
@@ -124,7 +128,7 @@ func main() {
 	}
 	log.Debugf("filterArgs = %v", filterArgs)
 
-	sendNotifications(time.Now().Format("02-01-2006 15:04:05"), "Starting docker event monitor")
+	sendNotifications(info, "Starting docker event monitor")
 
 	cli, err := client.NewClientWithOpts(client.FromEnv)
 	if err != nil {

--- a/src/docker-event-monitor.go
+++ b/src/docker-event-monitor.go
@@ -373,7 +373,7 @@ func processEvent(event *events.Message) {
 	message := strings.TrimRight(msg_builder.String(), "\n")
 
 	// Log message
-	log.Info(title + message)
+	log.Info(title + " " + message)
 
 	// send notifications to various reporters
 	// function will finish when all reporters finished

--- a/src/docker-event-monitor.go
+++ b/src/docker-event-monitor.go
@@ -1,4 +1,4 @@
-package main
+  package main
 
 import (
 	"context"
@@ -301,7 +301,7 @@ func processEvent(event *events.Message) {
 	// https://pkg.go.dev/github.com/docker/docker/api/types/events#Message
 
 	var msg_builder, title_builder, mid_builder strings.Builder
-	var ID, image, name, titleid string
+	var ActorID, ActorImage, ActorName, TitleID, title, mid string
 
 	// Adding a small configurable delay here
 	// Sometimes events are pushed through the event channel really quickly, but they arrive on the notification clients in
@@ -314,35 +314,35 @@ func processEvent(event *events.Message) {
 
 	//some events don't return Actor.ID or Actor.Attributes["image"]
 	if len(event.Actor.ID) > 0 {
-		ID = strings.TrimPrefix(event.Actor.ID, "sha256:")[:8] //remove prefix + limit ID legth
+		ActorID = strings.TrimPrefix(event.Actor.ID, "sha256:")[:8] //remove prefix + limit ActorID legth
 	}
 	if len(event.Actor.Attributes["image"]) > 0 {
-		image = event.Actor.Attributes["image"]
+		ActorImage = event.Actor.Attributes["image"]
 	}
 	if len(event.Actor.Attributes["name"]) > 0 {
-		name = event.Actor.Attributes["name"]
+		ActorName = event.Actor.Attributes["name"]
 	}
 
 	// Check possible image and container name
-	// The order of the checks is important, because we want name rather than ID
+	// The order of the checks is important, because we want name rather than ActorID
 	// as identifier in the title
-	if len(ID) > 0 {
-		mid_builder.WriteString("\nID: " + ID)
-		titleid = ID
+	if len(ActorID) > 0 {
+		mid_builder.WriteString("\nID: " + ActorID)
+		TitleID = ActorID
 	}
-	if len(image) > 0 {
-		mid_builder.WriteString("\nImage: " + image)
-		// Not using image as possible title, because it's too long
+	if len(ActorImage) > 0 {
+		mid_builder.WriteString("\nImage: " + ActorImage)
+		// Not using ActorImage as possible title, because it's too long
 	}
-	if len(name) > 0 {
-		mid_builder.WriteString("\nName: " + name)
-		titleid = name
+	if len(ActorName) > 0 {
+		mid_builder.WriteString("\nName: " + ActorName)
+		TitleID = ActorName
 	}
 
-	// Build message
+	// Build title
 	title_builder.WriteString(cases.Title(language.English, cases.Compact).String(event.Type))
-	if len(titleid) > 0 {
-		title_builder.WriteString(" " + titleid)
+	if len(TitleID) > 0 {
+		title_builder.WriteString(" " + TitleID)
 	}
 	title_builder.WriteString(": " + event.Action)
 

--- a/src/docker-event-monitor.go
+++ b/src/docker-event-monitor.go
@@ -194,6 +194,7 @@ func BuildMessage(timestamp time.Time, from string, to []string, subject string,
 	msg.WriteString("From: " + from + "\r\n")
 	msg.WriteString("To: " + strings.Join(to, ";") + "\r\n")
 	msg.WriteString("Date: " + timestamp.Format(time.RFC1123Z) + "\r\n")
+	msg.WriteString("Content-Type: text/plain; charset=UTF-8\r\n")
 	msg.WriteString("Subject: " + subject + "\r\n")
 	msg.WriteString("\r\n" + body + "\r\n")
 


### PR DESCRIPTION
As a base for further evolution on ...

When running `docker compose restart` for `unbound`:

![Screenshot from 2023-09-23 17-32-44](https://github.com/yubiuser/docker-event-monitor/assets/16748619/f148d7df-b5ca-42b7-8143-cf1bb3ee8636)

Exemplary mail:

![Screenshot from 2023-09-23 17-32-54](https://github.com/yubiuser/docker-event-monitor/assets/16748619/7891bf63-7e5a-4eda-9de9-23f75c6c31df)

and on mobile with K-9 mail:

![signal-2023-09-23-174346](https://github.com/yubiuser/docker-event-monitor/assets/16748619/9e3da4b5-5de2-4adb-ab78-84d7ae9f856a)

