### PR TITLE
Fix mod.go version. Must be in format x.y, not x.y.z

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -1,6 +1,6 @@
 module docker-event-monitor
 
-go 1.21.0
+go 1.21
 
 require (
 	github.com/alexflint/go-arg v1.4.3


### PR DESCRIPTION
When trying the VSCode extension for `golang`, I got the error
> invalid go version '1.21.0': must match format 1.23

Confirmed by looking at https://go.dev/doc/modules/gomod-ref