### PR TITLE
Separate delete workflows

### DIFF
--- a/.github/workflows/delete_PR_images.yml
+++ b/.github/workflows/delete_PR_images.yml
@@ -1,9 +1,6 @@
-name: Remove unused images from registry
+name: Remove obsolet PR images from registry
 
 on:
-  workflow_dispatch:
-  schedule:
-    - cron: "0 0 * * *"
   pull_request:
     types: [closed]
 
@@ -36,30 +33,3 @@ jobs:
           package-version-ids: ${{ env.VERSION_ID }}
           package-type: container
           package-name: ${{ env.PACKAGE_NAME }}
-
-  Delete_untagged_images:
-    runs-on: ubuntu-latest
-    permissions:
-      packages: write
-    if: |
-      github.event_name == 'workflow_dispatch'
-      || github.event_name == 'schedule'
-      || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
-    steps:
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3.0.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Delete all images from repository without tags
-        uses: Chizkiyahu/delete-untagged-ghcr-action@v2.0.1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          repository_owner: ${{ github.repository_owner }}
-          repository: ${{ github.repository }}
-          package_name: ${{ env.PACKAGE_NAME }}
-          untagged_only: true
-          owner_type: user
-          except_untagged_multiplatform: true

--- a/.github/workflows/delete_untagged_images.yml
+++ b/.github/workflows/delete_untagged_images.yml
@@ -1,0 +1,31 @@
+name: Remove untagged images from registry
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+env:
+  PACKAGE_NAME: docker-event-monitor
+
+jobs:
+  Delete_untagged_images:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.PAT_TOKEN }}
+
+      - name: Delete all images from repository without tags
+        uses: Chizkiyahu/delete-untagged-ghcr-action@v2.0.1
+        with:
+          token: ${{ secrets.PAT_TOKEN }}
+          repository_owner: ${{ github.repository_owner }}
+          repository: ${{ github.repository }}
+          package_name: ${{ env.PACKAGE_NAME }}
+          untagged_only: true
+          owner_type: user
+          except_untagged_multiplatform: true


### PR DESCRIPTION
Note: `Chizkiyahu/delete-untagged-ghcr-action@v2` really needs a PAT with `packages:delete`. Using `GITHUB_TOKEN` failed