### PR TITLE
Enable APIVersionNegotiation for docker connection

### DIFF
--- a/src/docker-event-monitor.go
+++ b/src/docker-event-monitor.go
@@ -134,10 +134,11 @@ func main() {
 		}
 	}
 
-	cli, err := client.NewClientWithOpts(client.FromEnv,client.WithAPIVersionNegotiation())
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
 		logger.Fatal().Err(err).Msg("")
 	}
+	defer cli.Close()
 
 	// receives events from the channel
 	event_chan, errs := cli.Events(context.Background(), types.EventsOptions{Filters: filterArgs})

--- a/src/docker-event-monitor.go
+++ b/src/docker-event-monitor.go
@@ -134,7 +134,7 @@ func main() {
 		}
 	}
 
-	cli, err := client.NewClientWithOpts(client.FromEnv)
+	cli, err := client.NewClientWithOpts(client.FromEnv,client.WithAPIVersionNegotiation())
 	if err != nil {
 		logger.Fatal().Err(err).Msg("")
 	}


### PR DESCRIPTION
PR https://github.com/yubiuser/docker-event-monitor/pull/63 Upgraded the used docker version to `v25` which sets the API version to `v1.44`.
Users with docker engines < v25 only had API version 1.43 and experienced a fatal error

```
{"level":"fatal","service":"docker event monitor","error":"Error response from daemon: client version 1.44 is too new. Maximum supported API version is 1.43","time":1706554624}
```

Adding the option `client.WithAPIVersionNegotiation()` within the `NewClientWithOpts` function should allow API negotiation between the client and the engine and fix the issue.

