### PR TITLE
Fix ActorID

### DIFF
--- a/src/docker-event-monitor.go
+++ b/src/docker-event-monitor.go
@@ -376,9 +376,12 @@ func processEvent(event *events.Message) {
 	// if logging level is Debug, log the event
 	logger.Debug().Msgf("%#v", event)
 
-	//some events don't return Actor.ID, Actor.Attributes["image"] or Actor.Attributes["name"]
-	if len(event.Actor.ID) > 0 && strings.HasPrefix(event.Actor.ID, "sha256:") {
-		ActorID = strings.TrimPrefix(event.Actor.ID, "sha256:")[:8] //remove prefix + limit ActorID legth
+	if len(event.Actor.ID) > 0 {
+		if strings.HasPrefix(event.Actor.ID, "sha256:") {
+			ActorID = strings.TrimPrefix(event.Actor.ID, "sha256:")[:8] //remove prefix + limit ActorID legth
+		} else {
+			ActorID = event.Actor.ID[:8] //limit ActorID legth
+		}
 	}
 	if len(event.Actor.Attributes["image"]) > 0 {
 		ActorImage = event.Actor.Attributes["image"]


### PR DESCRIPTION
Fixes a bug introduced by https://github.com/yubiuser/docker-event-monitor/pull/40/commits/144d5891b33dcc2fcd72e6d3d1f8d54ad071c2c2

This commit added a check for `Actor.ID` removing any leading `sha256` string. However, Actor.ID was only set if the check passed, rendering Actor.ID empty for any ID without a leading `sha256` string.