### PR TITLE
Unify reporters using httpClient requests

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -5,7 +5,6 @@ go 1.21
 require (
 	github.com/alexflint/go-arg v1.4.3
 	github.com/docker/docker v25.0.4+incompatible
-	github.com/gregdel/pushover v1.3.0
 	github.com/rs/zerolog v1.32.0
 	golang.org/x/text v0.14.0
 )

--- a/src/go.sum
+++ b/src/go.sum
@@ -37,8 +37,6 @@ github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/gregdel/pushover v1.3.0 h1:CewbxqsThoN/1imgwkDKFkRkltaQMoyBV0K9IquQLtw=
-github.com/gregdel/pushover v1.3.0/go.mod h1:EcaO66Nn1StkpEm1iKtBTV3d2A16SoMsVER1PthX7to=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 h1:YBftPWNWd4WwGqtY2yeZL2ef8rHAxPBD8KFhJpmcqms=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0/go.mod h1:YN5jB8ie0yfIUg6VvR9Kz84aCaG7AsGZnLjhHbUqwPg=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/src/gotify.go
+++ b/src/gotify.go
@@ -1,45 +1,28 @@
 package main
 
 import (
-	"io"
-	"net/http"
-	"net/url"
-	"time"
+	"encoding/json"
 )
 
+type GotifyMessage struct {
+	Title   string `json:"title"`
+	Message string `json:"message"`
+}
+
 func sendGotify(message string, title string) {
+	// Send a message to Gotify
 
-	// define custom httpClient with a default timeout
-	var netClient = &http.Client{
-		Timeout: time.Second * 10,
+	m := GotifyMessage{
+		Title:   title,
+		Message: message,
 	}
 
-	response, err := netClient.PostForm(glb_arguments.GotifyURL+"/message?token="+glb_arguments.GotifyToken,
-		url.Values{"message": {message}, "title": {title}})
+	messageJSON, err := json.Marshal(m)
 	if err != nil {
-		logger.Error().Err(err).Str("reporter", "Gotify").Msg("")
+		logger.Error().Err(err).Str("reporter", "Gotify").Msg("Faild to marshal JSON")
 		return
 	}
 
-	defer response.Body.Close()
-
-	statusCode := response.StatusCode
-
-	body, err := io.ReadAll(response.Body)
-	if err != nil {
-		logger.Error().Err(err).Str("reporter", "Gotify").Msg("")
-		return
-	}
-
-	logger.Debug().Str("reporter", "Gotify").Msgf("Gotify response statusCode: %d", statusCode)
-	logger.Debug().Str("reporter", "Gotify").Msgf("Gotify response body: %s", string(body))
-
-	// Log non successfull status codes
-	if statusCode == 200 {
-		logger.Debug().Str("reporter", "Gotify").Msgf("Gotify message delivered")
-	} else {
-		logger.Error().Str("reporter", "Gotify").Msgf("Pushing gotify message failed.")
-		logger.Error().Str("reporter", "Gotify").Msgf("Gotify response body: %s", string(body))
-	}
+	sendhttpMessage("Gotify", glb_arguments.GotifyURL+"/message?token="+glb_arguments.GotifyToken, messageJSON)
 
 }

--- a/src/gotify.go
+++ b/src/gotify.go
@@ -4,11 +4,17 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"time"
 )
 
 func sendGotify(message string, title string) {
 
-	response, err := http.PostForm(glb_arguments.GotifyURL+"/message?token="+glb_arguments.GotifyToken,
+	// define custom httpClient with a default timeout
+	var netClient = &http.Client{
+		Timeout: time.Second * 10,
+	}
+
+	response, err := netClient.PostForm(glb_arguments.GotifyURL+"/message?token="+glb_arguments.GotifyToken,
 		url.Values{"message": {message}, "title": {title}})
 	if err != nil {
 		logger.Error().Err(err).Str("reporter", "Gotify").Msg("")

--- a/src/mattermost.go
+++ b/src/mattermost.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"time"
 )
 
 // Adapted from https://github.com/mdeheij/mattergo
@@ -38,7 +39,12 @@ func sendMattermost(message string, title string) {
 		return
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	// define custom httpClient with a default timeout
+	var netClient = &http.Client{
+		Timeout: time.Second * 10,
+	}
+
+	resp, err := netClient.Do(req)
 	if err != nil {
 		logger.Error().Err(err).Str("reporter", "Mattermost").Msg("Faild to send request")
 		return

--- a/src/mattermost.go
+++ b/src/mattermost.go
@@ -1,11 +1,7 @@
 package main
 
 import (
-	"bytes"
 	"encoding/json"
-	"io"
-	"net/http"
-	"time"
 )
 
 // Adapted from https://github.com/mdeheij/mattergo
@@ -32,42 +28,6 @@ func sendMattermost(message string, title string) {
 		return
 	}
 
-	req, err := http.NewRequest("POST", glb_arguments.MattermostURL, bytes.NewBuffer(messageJSON))
-	req.Header.Set("Content-Type", "application/json; charset=UTF-8")
-	if err != nil {
-		logger.Error().Err(err).Str("reporter", "Mattermost").Msg("Faild to build request")
-		return
-	}
-
-	// define custom httpClient with a default timeout
-	var netClient = &http.Client{
-		Timeout: time.Second * 10,
-	}
-
-	resp, err := netClient.Do(req)
-	if err != nil {
-		logger.Error().Err(err).Str("reporter", "Mattermost").Msg("Faild to send request")
-		return
-	}
-	defer resp.Body.Close()
-
-	statusCode := resp.StatusCode
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		logger.Error().Err(err).Str("reporter", "Mattermost").Msg("")
-		return
-	}
-
-	logger.Debug().Str("reporter", "Mattermost").Msgf("Mattermost response statusCode: %d", statusCode)
-	logger.Debug().Str("reporter", "Mattermost").Msgf("Mattermost response body: %s", string(respBody))
-
-	// Log non successfull status codes
-	if statusCode == 200 {
-		logger.Debug().Str("reporter", "Mattermost").Msg("Mattermost message delivered")
-	} else {
-		logger.Error().Str("reporter", "Mattermost").Msg("Pushing Mattermost message failed.")
-		logger.Error().Str("reporter", "Mattermost").Msgf("Mattermost response body: %s", string(respBody))
-	}
+	sendhttpMessage("Mattermost", glb_arguments.MattermostURL, messageJSON)
 
 }

--- a/src/notifications.go
+++ b/src/notifications.go
@@ -21,7 +21,7 @@ func sendNotifications(timestamp time.Time, message string, title string) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			sendPushover(message, title)
+			sendPushover(timestamp, message, title)
 		}()
 	}
 

--- a/src/notifications.go
+++ b/src/notifications.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"bytes"
+	"io"
+	"net/http"
 	"sync"
 	"time"
 )
@@ -50,4 +53,51 @@ func sendNotifications(timestamp time.Time, message string, title string) {
 	}
 	wg.Wait()
 
+}
+
+func sendhttpMessage(reporter string, address string, messageJSON []byte) {
+
+	// Create request
+	req, err := http.NewRequest("POST", address, bytes.NewBuffer(messageJSON))
+	req.Header.Set("Content-Type", "application/json; charset=UTF-8")
+	if err != nil {
+		logger.Error().Err(err).Str("reporter", reporter).Msg("Faild to build request")
+		return
+	}
+
+	// define custom httpClient with a default timeout
+	var netClient = &http.Client{
+		Timeout: time.Second * 10,
+	}
+
+	// Send request
+	resp, err := netClient.Do(req)
+	if err != nil {
+		logger.Error().Err(err).Str("reporter", reporter).Msg("Faild to send request")
+		return
+	}
+	defer resp.Body.Close()
+
+	statusCode := resp.StatusCode
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		logger.Error().Err(err).Str("reporter", reporter).Msg("")
+		return
+	}
+
+	// Log non successfull status codes
+	if statusCode == 200 {
+		logger.Debug().
+			Str("reporter", reporter).
+			Int("statusCode", statusCode).
+			Str("responseBody", string(respBody)).
+			Msg("Message delivered")
+	} else {
+		logger.Error().
+			Str("reporter", reporter).
+			Int("statusCode", statusCode).
+			Str("responseBody", string(respBody)).
+			Msg("Pushing message failed.")
+	}
 }

--- a/src/pushover.go
+++ b/src/pushover.go
@@ -1,10 +1,7 @@
 package main
 
 import (
-	"bytes"
 	"encoding/json"
-	"io"
-	"net/http"
 	"strconv"
 	"time"
 )
@@ -34,48 +31,6 @@ func sendPushover(timestamp time.Time, message string, title string) {
 		return
 	}
 
-	// Create request
-	req, err := http.NewRequest("POST", "https://api.pushover.net/1/messages.json", bytes.NewBuffer(messageJSON))
-	req.Header.Set("Content-Type", "application/json; charset=UTF-8")
-	if err != nil {
-		logger.Error().Err(err).Str("reporter", "Pushover").Msg("Faild to build request")
-		return
-	}
-
-	// define custom httpClient with a default timeout
-	var netClient = &http.Client{
-		Timeout: time.Second * 10,
-	}
-
-	// Send request
-	resp, err := netClient.Do(req)
-	if err != nil {
-		logger.Error().Err(err).Str("reporter", "Pushover").Msg("Faild to send request")
-		return
-	}
-	defer resp.Body.Close()
-
-	statusCode := resp.StatusCode
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		logger.Error().Err(err).Str("reporter", "Pushover").Msg("")
-		return
-	}
-
-	// Log non successfull status codes
-	if statusCode == 200 {
-		logger.Debug().
-			Str("reporter", "Pushover").
-			Int("statusCode", statusCode).
-			Str("responseBody", string(respBody)).
-			Msg("Message delivered")
-	} else {
-		logger.Error().
-			Str("reporter", "Pushover").
-			Int("statusCode", statusCode).
-			Str("responseBody", string(respBody)).
-			Msg("Pushing message failed.")
-	}
+	sendhttpMessage("Pushover", "https://api.pushover.net/1/messages.json", messageJSON)
 
 }

--- a/src/pushover.go
+++ b/src/pushover.go
@@ -1,35 +1,81 @@
 package main
 
-import "github.com/gregdel/pushover"
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+)
 
-func sendPushover(message string, title string) {
-	// Create a new pushover app with an API token
-	app := pushover.New(glb_arguments.PushoverAPIToken)
+type PushoverMessage struct {
+	Token     string `json:"token"`
+	User      string `json:"user"`
+	Title     string `json:"title"`
+	Message   string `json:"message"`
+	Timestamp string `json:"timestamp"`
+}
 
-	// Create a new recipient (user key)
-	recipient := pushover.NewRecipient(glb_arguments.PushoverUserKey)
+func sendPushover(timestamp time.Time, message string, title string) {
+	// Send a message to Pushover
 
-	// Create the message to send
-	pushmessage := pushover.NewMessageWithTitle(message, title)
+	m := PushoverMessage{
+		Token:     glb_arguments.PushoverAPIToken,
+		User:      glb_arguments.PushoverUserKey,
+		Title:     title,
+		Message:   message,
+		Timestamp: strconv.FormatInt(timestamp.Unix(), 10),
+	}
 
-	// Send the message to the recipient
-	response, err := app.SendMessage(pushmessage, recipient)
+	messageJSON, err := json.Marshal(m)
+	if err != nil {
+		logger.Error().Err(err).Str("reporter", "Pushover").Msg("Faild to marshal JSON")
+		return
+	}
+
+	// Create request
+	req, err := http.NewRequest("POST", "https://api.pushover.net/1/messages.json", bytes.NewBuffer(messageJSON))
+	req.Header.Set("Content-Type", "application/json; charset=UTF-8")
+	if err != nil {
+		logger.Error().Err(err).Str("reporter", "Pushover").Msg("Faild to build request")
+		return
+	}
+
+	// define custom httpClient with a default timeout
+	var netClient = &http.Client{
+		Timeout: time.Second * 10,
+	}
+
+	// Send request
+	resp, err := netClient.Do(req)
+	if err != nil {
+		logger.Error().Err(err).Str("reporter", "Pushover").Msg("Faild to send request")
+		return
+	}
+	defer resp.Body.Close()
+
+	statusCode := resp.StatusCode
+
+	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		logger.Error().Err(err).Str("reporter", "Pushover").Msg("")
 		return
 	}
-	if response != nil {
-		logger.Debug().Str("reporter", "Pushover").Msgf("%s", response)
-	}
 
-	if response.Status == 1 {
-		// Pushover returns 1 if the message request to the API was valid
-		// https://pushover.net/api#response
-		logger.Debug().Str("reporter", "Pushover").Msgf("Pushover message delivered")
-		return
+	// Log non successfull status codes
+	if statusCode == 200 {
+		logger.Debug().
+			Str("reporter", "Pushover").
+			Int("statusCode", statusCode).
+			Str("responseBody", string(respBody)).
+			Msg("Message delivered")
+	} else {
+		logger.Error().
+			Str("reporter", "Pushover").
+			Int("statusCode", statusCode).
+			Str("responseBody", string(respBody)).
+			Msg("Pushing message failed.")
 	}
-
-	// if response Status !=1
-	logger.Error().Str("reporter", "Pushover").Msg("Pushover message not delivered")
 
 }

--- a/src/startup.go
+++ b/src/startup.go
@@ -32,7 +32,7 @@ func buildStartupMessage(timestamp time.Time) string {
 	}
 
 	if glb_arguments.Mattermost {
-		startup_message_builder.WriteString("\n Mattermost notification enabled")
+		startup_message_builder.WriteString("\nMattermost notification enabled")
 		if glb_arguments.MattermostChannel != "" {
 			startup_message_builder.WriteString("\nMattermost channel: " + glb_arguments.MattermostChannel)
 		}


### PR DESCRIPTION
- set timeout for http client connections to 10 seconds (defaults otherwise to no timeout)
- use default http client connection for Pushover notifications instead of external module
- create re-usuable http functions to re-use for mattermost/gotify/pushover notifications to reduce code duplication