### PR TITLE
Improve error handling

### DIFF
--- a/src/events.go
+++ b/src/events.go
@@ -85,7 +85,7 @@ func processEvent(event events.Message) {
 
 	// send notifications to various reporters
 	// function will finish when all reporters finished
-	sendNotifications(timestamp, message, title)
+	sendNotifications(timestamp, message, title, glb_arguments.Reporters)
 
 	// block function until time (delay) triggers
 	// if sendNotifications is faster than the delay, function blocks here until delay is over

--- a/src/gotify.go
+++ b/src/gotify.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 )
 
 type GotifyMessage struct {
@@ -23,8 +24,8 @@ func sendGotify(message string, title string, errCh chan ReporterError) {
 
 	messageJSON, err := json.Marshal(m)
 	if err != nil {
-		logger.Error().Err(err).Str("reporter", "Gotify").Msg("Faild to marshal JSON")
-		e.Error = err
+		logger.Error().Err(err).Str("reporter", "Gotify").Msg("Failed to marshal JSON")
+		e.Error = errors.New("failed to marshal JSON")
 		errCh <- e
 		return
 	}

--- a/src/gotify.go
+++ b/src/gotify.go
@@ -9,7 +9,7 @@ type GotifyMessage struct {
 	Message string `json:"message"`
 }
 
-func sendGotify(message string, title string) {
+func sendGotify(message string, title string, errCh chan ReporterError) {
 	// Send a message to Gotify
 
 	m := GotifyMessage{
@@ -17,12 +17,23 @@ func sendGotify(message string, title string) {
 		Message: message,
 	}
 
+	e := ReporterError{
+		Reporter: "Gotify",
+	}
+
 	messageJSON, err := json.Marshal(m)
 	if err != nil {
 		logger.Error().Err(err).Str("reporter", "Gotify").Msg("Faild to marshal JSON")
+		e.Error = err
+		errCh <- e
 		return
 	}
 
-	sendhttpMessage("Gotify", glb_arguments.GotifyURL+"/message?token="+glb_arguments.GotifyToken, messageJSON)
+	err = sendhttpMessage("Gotify", glb_arguments.GotifyURL+"/message?token="+glb_arguments.GotifyToken, messageJSON)
+	if err != nil {
+		e.Error = err
+		errCh <- e
+		return
+	}
 
 }

--- a/src/mail.go
+++ b/src/mail.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"net/smtp"
 	"strconv"
 	"strings"
@@ -44,7 +45,7 @@ func sendMail(timestamp time.Time, message string, title string, errCh chan Repo
 	err := smtp.SendMail(address, auth, from, to, []byte(mail))
 	if err != nil {
 		logger.Error().Err(err).Str("reporter", "Mail").Msg("")
-		e.Error = err
+		e.Error = errors.New("failed to send mail")
 		errCh <- e
 		return
 	}

--- a/src/mail.go
+++ b/src/mail.go
@@ -19,7 +19,11 @@ func buildEMail(timestamp time.Time, from string, to []string, subject string, b
 	return msg.String()
 }
 
-func sendMail(timestamp time.Time, message string, title string) {
+func sendMail(timestamp time.Time, message string, title string, errCh chan ReporterError) {
+
+	e := ReporterError{
+		Reporter: "Mail",
+	}
 
 	from := glb_arguments.MailFrom
 	to := []string{glb_arguments.MailTo}
@@ -40,6 +44,9 @@ func sendMail(timestamp time.Time, message string, title string) {
 	err := smtp.SendMail(address, auth, from, to, []byte(mail))
 	if err != nil {
 		logger.Error().Err(err).Str("reporter", "Mail").Msg("")
+		e.Error = err
+		errCh <- e
 		return
 	}
+
 }

--- a/src/main.go
+++ b/src/main.go
@@ -32,6 +32,7 @@ type args struct {
 	MattermostURL     string              `arg:"env:MATTERMOST_URL" help:"URL of your Mattermost incoming webhook"`
 	MattermostChannel string              `arg:"env:MATTERMOST_CHANNEL" help:"Mattermost channel to post in"`
 	MattermostUser    string              `arg:"env:MATTERMOST_USER" default:"Docker Event Monitor" help:"Mattermost user to post as"`
+	Reporters         []string            `arg:"-"`
 	Delay             time.Duration       `arg:"env:DELAY" default:"500ms" help:"Delay before next message is send"`
 	FilterStrings     []string            `arg:"env:FILTER,--filter,separate" help:"Filter docker events using Docker syntax."`
 	Filter            map[string][]string `arg:"-"`
@@ -112,7 +113,7 @@ func main() {
 
 	timestamp := time.Now()
 	startup_message := buildStartupMessage(timestamp)
-	sendNotifications(timestamp, startup_message, "Starting docker event monitor")
+	sendNotifications(timestamp, startup_message, "Starting docker event monitor", glb_arguments.Reporters)
 
 	filterArgs := filters.NewArgs()
 	for key, values := range glb_arguments.Filter {
@@ -179,6 +180,21 @@ func parseArgs() {
 		key := strings.TrimSpace(exclude[:pos])
 		val := exclude[pos+1:]
 		glb_arguments.Exclude[key] = append(glb_arguments.Exclude[key], val)
+	}
+
+	//Parse enabled reportes
+
+	if glb_arguments.Gotify {
+		glb_arguments.Reporters = append(glb_arguments.Reporters, "Gotify")
+	}
+	if glb_arguments.Mattermost {
+		glb_arguments.Reporters = append(glb_arguments.Reporters, "Mattermost")
+	}
+	if glb_arguments.Pushover {
+		glb_arguments.Reporters = append(glb_arguments.Reporters, "Pushover")
+	}
+	if glb_arguments.Mail {
+		glb_arguments.Reporters = append(glb_arguments.Reporters, "Mail")
 	}
 
 }

--- a/src/mattermost.go
+++ b/src/mattermost.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 )
 
 // Adapted from https://github.com/mdeheij/mattergo
@@ -28,8 +29,8 @@ func sendMattermost(message string, title string, errCh chan ReporterError) {
 
 	messageJSON, err := json.Marshal(m)
 	if err != nil {
-		logger.Error().Err(err).Str("reporter", "Mattermost").Msg("Faild to marshal JSON")
-		e.Error = err
+		logger.Error().Err(err).Str("reporter", "Mattermost").Msg("Failed to marshal JSON")
+		e.Error = errors.New("failed to marshal JSON")
 		errCh <- e
 		return
 	}

--- a/src/mattermost.go
+++ b/src/mattermost.go
@@ -14,7 +14,7 @@ type MattermostMessage struct {
 }
 
 // Send a message to a Mattermost chat channel
-func sendMattermost(message string, title string) {
+func sendMattermost(message string, title string, errCh chan ReporterError) {
 
 	m := MattermostMessage{
 		Username: glb_arguments.MattermostUser,
@@ -22,12 +22,23 @@ func sendMattermost(message string, title string) {
 		Text:     "##### " + title + "\n" + message,
 	}
 
+	e := ReporterError{
+		Reporter: "Mattermost",
+	}
+
 	messageJSON, err := json.Marshal(m)
 	if err != nil {
 		logger.Error().Err(err).Str("reporter", "Mattermost").Msg("Faild to marshal JSON")
+		e.Error = err
+		errCh <- e
 		return
 	}
 
-	sendhttpMessage("Mattermost", glb_arguments.MattermostURL, messageJSON)
+	err = sendhttpMessage("Mattermost", glb_arguments.MattermostURL, messageJSON)
+	if err != nil {
+		e.Error = err
+		errCh <- e
+		return
+	}
 
 }

--- a/src/notifications.go
+++ b/src/notifications.go
@@ -2,67 +2,119 @@ package main
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
+	"slices"
+	"strconv"
 	"sync"
 	"time"
 )
 
-func sendNotifications(timestamp time.Time, message string, title string) {
+type ReporterError struct {
+	Reporter string
+	Error    error
+}
+
+func sendNotifications(timestamp time.Time, message string, title string, reporters []string) {
 	// Sending messages to different services as goroutines concurrently
 	// Adding a wait group here to delay execution until all functions return,
 	// otherwise delaying in processEvent() would not make any sense
 
 	var wg sync.WaitGroup
+	var ReporterErrors []ReporterError
+
+	// Buffered error channel with a buffer size of the number of enabled reporters
+	errCh := make(chan ReporterError, len(reporters))
 
 	// If there is a server tag, add it to the title
 	if len(glb_arguments.ServerTag) > 0 {
 		title = "[" + glb_arguments.ServerTag + "] " + title
 	}
 
-	if glb_arguments.Pushover {
+	if slices.Contains(reporters, "Pushover") {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			sendPushover(timestamp, message, title)
+			sendPushover(timestamp, message, title, errCh)
 		}()
 	}
 
-	if glb_arguments.Gotify {
+	if slices.Contains(reporters, "Gotify") {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			sendGotify(message, title)
+			sendGotify(message, title, errCh)
 		}()
 	}
 
-	if glb_arguments.Mail {
+	if slices.Contains(reporters, "Mail") {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			sendMail(timestamp, message, title)
+			sendMail(timestamp, message, title, errCh)
 		}()
 	}
 
-	if glb_arguments.Mattermost {
+	if slices.Contains(reporters, "Mattermost") {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			sendMattermost(message, title)
+			sendMattermost(message, title, errCh)
 		}()
 	}
 	wg.Wait()
 
+	// all reporters finished, closign the error channel
+	close(errCh)
+
+	// iterate over the items in the error channel
+	for err := range errCh {
+		ReporterErrors = append(ReporterErrors, err)
+	}
+
+	// if some reporters failed, send notifications to all working reporters
+	if len(ReporterErrors) > 0 {
+
+		// Error if all failed
+		if len(ReporterErrors) == len(reporters) {
+			logger.Error().Msg("All reporters failed!")
+			return
+		}
+
+		// iterate over the failed reportes and remove them from all enabled reports
+		// send error notifications to remaining (working) reporters
+		for _, item := range ReporterErrors {
+			reporters = removeFromSlice(reporters, item.Reporter)
+		}
+
+		for _, item := range ReporterErrors {
+			err := fmt.Sprint(item.Error)
+			sendNotifications(time.Now(), "{"+err+"}", "Error: Reporter "+item.Reporter+" failed", reporters)
+		}
+
+	}
 }
 
-func sendhttpMessage(reporter string, address string, messageJSON []byte) {
+func removeFromSlice(slice []string, element string) []string {
+	var result []string
+	for _, item := range slice {
+		if item != element {
+			result = append(result, item)
+		}
+	}
+	return result
+}
+
+func sendhttpMessage(reporter string, address string, messageJSON []byte) error {
 
 	// Create request
 	req, err := http.NewRequest("POST", address, bytes.NewBuffer(messageJSON))
 	req.Header.Set("Content-Type", "application/json; charset=UTF-8")
 	if err != nil {
 		logger.Error().Err(err).Str("reporter", reporter).Msg("Faild to build request")
-		return
+		return err
 	}
 
 	// define custom httpClient with a default timeout
@@ -74,7 +126,7 @@ func sendhttpMessage(reporter string, address string, messageJSON []byte) {
 	resp, err := netClient.Do(req)
 	if err != nil {
 		logger.Error().Err(err).Str("reporter", reporter).Msg("Faild to send request")
-		return
+		return err
 	}
 	defer resp.Body.Close()
 
@@ -83,21 +135,22 @@ func sendhttpMessage(reporter string, address string, messageJSON []byte) {
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		logger.Error().Err(err).Str("reporter", reporter).Msg("")
-		return
+		return err
 	}
 
 	// Log non successfull status codes
-	if statusCode == 200 {
-		logger.Debug().
-			Str("reporter", reporter).
-			Int("statusCode", statusCode).
-			Str("responseBody", string(respBody)).
-			Msg("Message delivered")
-	} else {
+	if statusCode != 200 {
 		logger.Error().
 			Str("reporter", reporter).
 			Int("statusCode", statusCode).
 			Str("responseBody", string(respBody)).
-			Msg("Pushing message failed.")
+			Msg("Pushing message failed")
+		return errors.New("Pushing message failed\nstatusCode: " + strconv.Itoa(statusCode) + "\nresponseBody: " + string(respBody))
 	}
+	logger.Debug().
+		Str("reporter", reporter).
+		Int("statusCode", statusCode).
+		Str("responseBody", string(respBody)).
+		Msg("Message delivered")
+	return nil
 }

--- a/src/pushover.go
+++ b/src/pushover.go
@@ -14,7 +14,7 @@ type PushoverMessage struct {
 	Timestamp string `json:"timestamp"`
 }
 
-func sendPushover(timestamp time.Time, message string, title string) {
+func sendPushover(timestamp time.Time, message string, title string, errCh chan ReporterError) {
 	// Send a message to Pushover
 
 	m := PushoverMessage{
@@ -25,12 +25,23 @@ func sendPushover(timestamp time.Time, message string, title string) {
 		Timestamp: strconv.FormatInt(timestamp.Unix(), 10),
 	}
 
+	e := ReporterError{
+		Reporter: "Pushover",
+	}
+
 	messageJSON, err := json.Marshal(m)
 	if err != nil {
 		logger.Error().Err(err).Str("reporter", "Pushover").Msg("Faild to marshal JSON")
+		e.Error = err
+		errCh <- e
 		return
 	}
 
-	sendhttpMessage("Pushover", "https://api.pushover.net/1/messages.json", messageJSON)
+	err = sendhttpMessage("Pushover", "https://api.pushover.net/1/messages.json", messageJSON)
+	if err != nil {
+		e.Error = err
+		errCh <- e
+		return
+	}
 
 }

--- a/src/pushover.go
+++ b/src/pushover.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"strconv"
 	"time"
 )
@@ -31,8 +32,8 @@ func sendPushover(timestamp time.Time, message string, title string, errCh chan 
 
 	messageJSON, err := json.Marshal(m)
 	if err != nil {
-		logger.Error().Err(err).Str("reporter", "Pushover").Msg("Faild to marshal JSON")
-		e.Error = err
+		logger.Error().Err(err).Str("reporter", "Pushover").Msg("Failed to marshal JSON")
+		e.Error = errors.New("failed to marshal JSON")
 		errCh <- e
 		return
 	}


### PR DESCRIPTION
If an error occurs during sending a message to a reporter, an error notification will be send to all working reporters. The actual error message is not send as it can contain sensitive information (e.g. App Tokens, Webhook URLs).