### PR TITLE
Remove delay option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -69,7 +69,6 @@ Currently the following options can be set via `config.yml`
 ```yaml
 ---
 options:
-  delay: 500ms
   filter_strings: ["type=container"]
   exclude_strings: ["Action=exec_start", "Action=exec_die", "Action=exec_create"]
   log_level: debug

--- a/src/config.yml
+++ b/src/config.yml
@@ -1,6 +1,5 @@
 ---
 options:
-  delay: 500ms
   filter_strings: ["type=container"]
   exclude_strings: ["Action=exec_start", "Action=exec_die", "Action=exec_create"]
   log_level: debug

--- a/src/events.go
+++ b/src/events.go
@@ -18,12 +18,6 @@ func processEvent(event events.Message) {
 	var msg_builder, title_builder strings.Builder
 	var ActorID, ActorImage, ActorName, TitleID, ActorImageVersion string
 
-	// Adding a small configurable delay here
-	// Sometimes events are pushed through the event channel really quickly, but they arrive on the notification clients in
-	// wrong order (probably due to message delivery time), e.g. Pushover is susceptible for this.
-	// Finishing this function not before a certain time before draining the next event from the event channel in main() solves the issue
-	timer := time.NewTimer(config.Options.Delay)
-
 	ActorID = getActorID(event)
 	ActorImage = getActorImage(event)
 	ActorName = getActorName(event)
@@ -87,11 +81,6 @@ func processEvent(event events.Message) {
 	// send notifications to various reporters
 	// function will finish when all reporters finished
 	sendNotifications(timestamp, message, title, config.Reporters)
-
-	// block function until time (delay) triggers
-	// if sendNotifications is faster than the delay, function blocks here until delay is over
-	// if sendNotifications takes longer than the delay, trigger already fired and no delay is added
-	<-timer.C
 
 }
 

--- a/src/notifications.go
+++ b/src/notifications.go
@@ -22,7 +22,6 @@ type ReporterError struct {
 func sendNotifications(timestamp time.Time, message string, title string, reporters []string) {
 	// Sending messages to different services as goroutines concurrently
 	// Adding a wait group here to delay execution until all functions return,
-	// otherwise delaying in processEvent() would not make any sense
 
 	var wg sync.WaitGroup
 	var ReporterErrors []ReporterError

--- a/src/startup.go
+++ b/src/startup.go
@@ -44,12 +44,6 @@ func buildStartupMessage(timestamp time.Time) string {
 		startup_message_builder.WriteString("\nMattermost notification disabled")
 	}
 
-	if config.Options.Delay > 0 {
-		startup_message_builder.WriteString("\nUsing delay of " + config.Options.Delay.String())
-	} else {
-		startup_message_builder.WriteString("\nDelay disabled")
-	}
-
 	startup_message_builder.WriteString("\nLog level: " + config.Options.LogLevel)
 
 	if config.Options.ServerTag != "" {
@@ -102,7 +96,6 @@ func logArguments() {
 					Str("MattermostUser", config.Reporter.Mattermost.User),
 				),
 			).
-			Str("Delay", config.Options.Delay.String()).
 			Str("Loglevel", config.Options.LogLevel).
 			Str("ServerTag", config.Options.ServerTag).
 			Str("Filter", strings.Join(config.Options.FilterStrings, " ")).

--- a/src/types.go
+++ b/src/types.go
@@ -1,7 +1,5 @@
 package main
 
-import "time"
-
 type pushover struct {
 	Enabled  bool
 	APIToken string `yaml:"api_token"`
@@ -36,11 +34,10 @@ type reporter struct {
 }
 
 type options struct {
-	FilterStrings  []string      `yaml:"filter_strings,flow"`
-	ExcludeStrings []string      `yaml:"exclude_strings,flow"`
-	LogLevel       string        `yaml:"log_level"`
-	ServerTag      string        `yaml:"server_tag"`
-	Delay          time.Duration `yaml:"delay"`
+	FilterStrings  []string `yaml:"filter_strings,flow"`
+	ExcludeStrings []string `yaml:"exclude_strings,flow"`
+	LogLevel       string   `yaml:"log_level"`
+	ServerTag      string   `yaml:"server_tag"`
 }
 
 type Config struct {


### PR DESCRIPTION
Removing the delay option. It was introduced to "order" events arriving on reporters when events happen very quickly. It was mainly used for `pushover`. But since conveying the event's timestamp in the pushover message by using the generic httpClient (https://github.com/yubiuser/docker-event-monitor/commit/a52d8429bcf02a816d551e0d16ad14c85b1d6304) it should not be necessary anymore. 

Only for sub-second events message can arrive out-of-order. I already submitted a feature request to Pushover to allow nanosecond timestamps, but haven't heard from them yet.