### PR TITLE
Use arm64 runners for arm builds

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on:  ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
@@ -23,10 +23,15 @@ jobs:
       matrix:
         include:
           - platform: linux/amd64
+            runner: ubuntu-latest
           - platform: linux/arm64
+            runner: ubuntu-24.04-arm
           - platform: linux/arm/v6
+            runner: ubuntu-24.04-arm
           - platform: linux/arm/v7
-          - platform: linux/386
+            runner: ubuntu-24.04-arm
+          - platform: linux/386,
+            runner: ubuntu-latest
     steps:
       - name: Prepare name for digest up/download
         run: |


### PR DESCRIPTION
This should speedup builds a lot