### PR TITLE
Add crash_only option for per-container notification filtering

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -27,7 +27,8 @@ jobs:
       GIT_DATE: ${{ env.GIT_DATE }}
     steps:
       # FIXME: can't use env object in reusable workflow inputs: https://github.com/orgs/community/discussions/26671
-      - run: echo "Exposing env vars for reusable workflow"
+      - name: Lowercase registry image name
+        run: echo "REGISTRY_IMAGE=${REGISTRY_IMAGE,,}" >> $GITHUB_ENV
 
       - name: Checkout Code
         uses: actions/checkout@v6.0.2

--- a/Readme.md
+++ b/Readme.md
@@ -71,6 +71,7 @@ Currently the following options can be set via `config.yml`
 options:
   filter_strings: ["type=container"]
   exclude_strings: ["Action=exec_start", "Action=exec_die", "Action=exec_create"]
+  crash_only: ["^my-(test|staging)-app"]
   log_level: debug
   server_tag: My Server
 
@@ -114,3 +115,29 @@ The syntax for exclusion is also `key=value`.  But as the exclusion happens on t
 ```
 
 Keys of nested elements are joind by dots. E.g. `Actor.Attributes.com.docker.compose.project` or `Actor.Attributes.image`.
+
+### Crash-only monitoring
+
+For containers where you only want to be notified about real crashes (not routine restarts, updates, or stops), use the `crash_only` option. It takes a list of substrings matched against the container name and image:
+
+```yaml
+options:
+  crash_only: ["^my-(test|beta)-app"]
+```
+
+Containers matching any of these patterns will only generate notifications for `die` events with a non-zero exit code that isn't a signal-based stop. Specifically:
+
+| Event | Exit code | Notified? |
+|-------|-----------|-----------|
+| `start`, `stop`, `kill`, `create` | — | No |
+| `die` | 0 (clean exit) | No |
+| `die` | 137 (SIGKILL) / 143 (SIGTERM) | No |
+| `die` | Any other non-zero | **Yes** (crash) |
+
+This is useful for development/staging containers that are frequently restarted or redeployed (e.g. by Watchtower) and would otherwise flood notifications. Patterns are matched as [Go regular expressions](https://pkg.go.dev/regexp/syntax) against both the container name and the image name. Examples:
+
+| Pattern | Matches |
+|---------|---------|
+| `my-test-app` | Any name containing `my-test-app` (substring), including `my-test-app-db-1` |
+| `^my-test-app$` | Only the exact name `my-test-app` |
+| `^my-(test\|beta)-app` | Names starting with `my-test-app` or `my-beta-app` (and their suffixes like `-db-1`) |

--- a/Readme.md
+++ b/Readme.md
@@ -118,7 +118,7 @@ Keys of nested elements are joind by dots. E.g. `Actor.Attributes.com.docker.com
 
 ### Crash-only monitoring
 
-For containers where you only want to be notified about real crashes (not routine restarts, updates, or stops), use the `crash_only` option. It takes a list of substrings matched against the container name and image:
+For containers where you only want to be notified about real crashes (not routine restarts, updates, or stops), use the `crash_only` option. It takes a list of [Go regular expressions](https://pkg.go.dev/regexp/syntax) matched against the container name and image:
 
 ```yaml
 options:
@@ -140,4 +140,4 @@ This is useful for development/staging containers that are frequently restarted 
 |---------|---------|
 | `my-test-app` | Any name containing `my-test-app` (substring), including `my-test-app-db-1` |
 | `^my-test-app$` | Only the exact name `my-test-app` |
-| `^my-(test\|beta)-app` | Names starting with `my-test-app` or `my-beta-app` (and their suffixes like `-db-1`) |
+| `^my-(test|beta)-app` | Names starting with `my-test-app` or `my-beta-app` (and their suffixes like `-db-1`) |

--- a/src/events.go
+++ b/src/events.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"regexp"
 	"strings"
 	"time"
 
@@ -137,11 +136,16 @@ func getActorName(event events.Message) string {
 
 }
 
-func isCrashOnlyEvent(event events.Message) bool {
+func shouldSuppressForCrashOnly(event events.Message) bool {
 	// For containers matching crash_only patterns, suppress all events
 	// except "die" with a non-zero exit code that isn't a signal-based stop.
 	// Exit codes 137 (SIGKILL) and 143 (SIGTERM) are normal Docker stop signals.
-	if len(config.Options.CrashOnly) == 0 {
+	if len(config.CrashOnlyRegexps) == 0 {
+		return false
+	}
+
+	// crash_only is a per-container filter; ignore non-container events
+	if event.Type != "container" {
 		return false
 	}
 
@@ -149,10 +153,8 @@ func isCrashOnlyEvent(event events.Message) bool {
 	image := getActorImage(event)
 
 	matched := false
-	for _, pattern := range config.Options.CrashOnly {
-		nameMatch, _ := regexp.MatchString(pattern, name)
-		imageMatch, _ := regexp.MatchString(pattern, image)
-		if nameMatch || imageMatch {
+	for _, re := range config.CrashOnlyRegexps {
+		if re.MatchString(name) || re.MatchString(image) {
 			matched = true
 			break
 		}
@@ -170,7 +172,13 @@ func isCrashOnlyEvent(event events.Message) bool {
 		return true
 	}
 
-	exitCode := event.Actor.Attributes["exitCode"]
+	exitCode, ok := event.Actor.Attributes["exitCode"]
+	if !ok || exitCode == "" {
+		log.Debug().
+			Str("ActorName", name).
+			Msg("Suppressed (crash_only: missing exit code)")
+		return true
+	}
 	if exitCode == "0" || exitCode == "137" || exitCode == "143" {
 		log.Debug().
 			Str("ActorName", name).
@@ -179,7 +187,7 @@ func isCrashOnlyEvent(event events.Message) bool {
 		return true
 	}
 
-	log.Info().
+	log.Debug().
 		Str("ActorName", name).
 		Str("exitCode", exitCode).
 		Msg("Crash detected (crash_only: non-zero exit)")

--- a/src/events.go
+++ b/src/events.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"regexp"
 	"strings"
 	"time"
 
@@ -134,6 +135,55 @@ func getActorName(event events.Message) string {
 	}
 	return ActorName
 
+}
+
+func isCrashOnlyEvent(event events.Message) bool {
+	// For containers matching crash_only patterns, suppress all events
+	// except "die" with a non-zero exit code that isn't a signal-based stop.
+	// Exit codes 137 (SIGKILL) and 143 (SIGTERM) are normal Docker stop signals.
+	if len(config.Options.CrashOnly) == 0 {
+		return false
+	}
+
+	name := getActorName(event)
+	image := getActorImage(event)
+
+	matched := false
+	for _, pattern := range config.Options.CrashOnly {
+		nameMatch, _ := regexp.MatchString(pattern, name)
+		imageMatch, _ := regexp.MatchString(pattern, image)
+		if nameMatch || imageMatch {
+			matched = true
+			break
+		}
+	}
+	if !matched {
+		return false
+	}
+
+	// Container matches a crash_only pattern — only allow "die" with a real crash exit code
+	if event.Action != "die" {
+		log.Debug().
+			Str("ActorName", name).
+			Str("Action", string(event.Action)).
+			Msg("Suppressed (crash_only: not a die event)")
+		return true
+	}
+
+	exitCode := event.Actor.Attributes["exitCode"]
+	if exitCode == "0" || exitCode == "137" || exitCode == "143" {
+		log.Debug().
+			Str("ActorName", name).
+			Str("exitCode", exitCode).
+			Msg("Suppressed (crash_only: clean/signal exit)")
+		return true
+	}
+
+	log.Info().
+		Str("ActorName", name).
+		Str("exitCode", exitCode).
+		Msg("Crash detected (crash_only: non-zero exit)")
+	return false
 }
 
 func excludeEvent(event events.Message) bool {

--- a/src/main.go
+++ b/src/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -142,6 +143,15 @@ func parseArgs() {
 		config.Exclude[key] = append(config.Exclude[key], val)
 	}
 
+	// Compile crash_only patterns
+	for _, pattern := range config.Options.CrashOnly {
+		re, err := regexp.Compile(pattern)
+		if err != nil {
+			log.Fatal().Err(err).Msgf("Invalid crash_only pattern: %s", pattern)
+		}
+		config.CrashOnlyRegexps = append(config.CrashOnlyRegexps, re)
+	}
+
 	//Parse Enabled reportes
 
 	if config.Reporter.Gotify.Enabled {
@@ -216,8 +226,8 @@ func main() {
 					break //breaks out of the select and waits for the next event to arrive
 				}
 			}
-			// Check if event is from a crash_only container
-			if isCrashOnlyEvent(event) {
+			// Check if event should be suppressed by crash_only filter
+			if shouldSuppressForCrashOnly(event) {
 				break
 			}
 			processEvent(event)

--- a/src/main.go
+++ b/src/main.go
@@ -216,6 +216,10 @@ func main() {
 					break //breaks out of the select and waits for the next event to arrive
 				}
 			}
+			// Check if event is from a crash_only container
+			if isCrashOnlyEvent(event) {
+				break
+			}
 			processEvent(event)
 		}
 	}

--- a/src/startup.go
+++ b/src/startup.go
@@ -64,6 +64,12 @@ func buildStartupMessage(timestamp time.Time) string {
 		startup_message_builder.WriteString("\nExcludeStrings: none")
 	}
 
+	if len(config.Options.CrashOnly) > 0 {
+		startup_message_builder.WriteString("\nCrashOnly: " + strings.Join(config.Options.CrashOnly, ", "))
+	} else {
+		startup_message_builder.WriteString("\nCrashOnly: none")
+	}
+
 	return startup_message_builder.String()
 }
 

--- a/src/types.go
+++ b/src/types.go
@@ -34,10 +34,11 @@ type reporter struct {
 }
 
 type options struct {
-	FilterStrings  []string `yaml:"filter_strings,flow"`
-	ExcludeStrings []string `yaml:"exclude_strings,flow"`
-	LogLevel       string   `yaml:"log_level"`
-	ServerTag      string   `yaml:"server_tag"`
+	FilterStrings    []string `yaml:"filter_strings,flow"`
+	ExcludeStrings   []string `yaml:"exclude_strings,flow"`
+	CrashOnly        []string `yaml:"crash_only,flow"`
+	LogLevel         string   `yaml:"log_level"`
+	ServerTag        string   `yaml:"server_tag"`
 }
 
 type Config struct {

--- a/src/types.go
+++ b/src/types.go
@@ -1,5 +1,7 @@
 package main
 
+import "regexp"
+
 type pushover struct {
 	Enabled  bool
 	APIToken string `yaml:"api_token"`
@@ -42,9 +44,10 @@ type options struct {
 }
 
 type Config struct {
-	Reporter        reporter
-	Options         options
-	EnabledReporter []string            `yaml:"-"`
-	Filter          map[string][]string `yaml:"-"`
-	Exclude         map[string][]string `yaml:"-"`
+	Reporter         reporter
+	Options          options
+	EnabledReporter  []string            `yaml:"-"`
+	Filter           map[string][]string `yaml:"-"`
+	Exclude          map[string][]string `yaml:"-"`
+	CrashOnlyRegexps []*regexp.Regexp    `yaml:"-"`
 }


### PR DESCRIPTION
Add a new `crash_only` configuration option that suppresses notifications for matched containers unless they actually crash. This is useful for development, test, and staging containers that are frequently restarted or redeployed (e.g. by Watchtower) and would otherwise flood notifications.

Containers matching any `crash_only` pattern only generate notifications for `die` events with a non-zero exit code that isn't a signal-based stop (exit codes 137/`SIGKILL` and 143/`SIGTERM` are treated as normal stops and suppressed).

Patterns are matched as Go regular expressions against both the container name and image name, supporting anchors and groups:

``` yaml
crash_only: ["^my-(test|beta)-app"]
```

All other containers are unaffected and continue to report all events as before. The crash_only check runs after the existing exclude filter.